### PR TITLE
Remove unnecessary default function

### DIFF
--- a/contracts/BalanceScanner.sol
+++ b/contracts/BalanceScanner.sol
@@ -40,11 +40,4 @@ contract BalanceScanner {
       balances[i] = tokenContract.balanceOf(addresses[i]);
     }
   }
-
-  /**
-   * @notice This contract does not accept ETH payments.
-   */
-  function() external payable {
-    revert();
-  }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "types": "typings/index.d.ts",
   "repository": "https://github.com/Mrtenz/eth-scan.git",
   "author": "Maarten Zuidhoorn <maarten@zuidhoorn.com>",
+  "contributors": [
+    "Luit Hollander <luit@hollander.email> (https://luit.me)"
+  ],
   "license": "MIT",
   "files": [
     "dist",


### PR DESCRIPTION
The following code is no longer necessary:

```
/**
   * @notice This contract does not accept ETH payments.
   */
  function() external payable {
    revert();
  }
```

"Contracts now throw if no payable fallback function is defined and no function matches the signature."

https://github.com/ethereum/solidity/blob/develop/Changelog.md#040-2016-09-08

Also see: https://ethereum.stackexchange.com/questions/34160/why-do-we-use-revert-in-payable-function